### PR TITLE
Fix: Column 'type' in where clause is ambiguous

### DIFF
--- a/src/Resources/contao/library/MarketingSuite/MarketingItem/ABTestPage.php
+++ b/src/Resources/contao/library/MarketingSuite/MarketingItem/ABTestPage.php
@@ -218,7 +218,7 @@ class ABTestPage extends MarketingItem {
         // NOTE: this won't be called when domain.tld/ is requested
 
         $objPage = null;
-        $objPages = PageModel::findBy(['alias=?'], $arrFragments[0]);
+        $objPages = PageModel::findBy(['tl_page.alias=?'], $arrFragments[0]);
 
         $rootPageId = Frontend::getRootPageFromUrl();
 

--- a/src/Resources/contao/models/LinkShortenerModel.php
+++ b/src/Resources/contao/models/LinkShortenerModel.php
@@ -41,11 +41,11 @@ class LinkShortenerModel extends Model {
      */
     public static function findOneByPath($path) {
 
-        $oRoot = PageModel::findOneBy(['type=? AND (dns=? OR dns=?)'], ['root', Environment::get('httpHost'), '']);
+        $oRoot = PageModel::findOneBy(['tl_page.type=? AND (tl_page.dns=? OR tl_page.dns=?)'], ['root', Environment::get('httpHost'), '']);
 
         if( lskgn::hasFeature('link_shortener', $oRoot->id) ) {
 
-            return self::findOneBy(['(prefix=? OR alias=?) AND domain=?'], [$path, $path, Environment::get('httpHost')]);
+            return self::findOneBy(['(tl_page.prefix=? OR tl_page.alias=?) AND tl_page.domain=?'], [$path, $path, Environment::get('httpHost')]);
         }
 
         return null;


### PR DESCRIPTION
Fix error:
```
An exception occurred while executing 'SELECT tl_page.*, j1.`id` AS pwChangePage__id, j1.`pid` AS pwChangePage__pid, j1.`sorting` AS pwChangePage__sorting, j1.`tstamp` AS pwChangePage__tstamp, j1.`title` AS pwChangePage__title, j1.`alias` AS pwChangePage__alias, j1.`type` AS pwChangePage__type, j1.`pageTitle` AS pwChangePage__pageTitle, j1.`language` AS pwChangePage__language, j1.`robots` AS pwChangePage__robots, j1.`description` AS pwChangePage__description, j1.`redirect` AS pwChangePage__redirect, j1.`jumpTo` AS pwChangePage__jumpTo, j1.`redirectBack` AS pwChangePage__redirectBack, j1.`url` AS pwChangePage__url, j1.`target` AS pwChangePage__target, j1.`dns` AS pwChangePage__dns, j1.`staticFiles` AS pwChangePage__staticFiles, j1.`staticPlugins` AS pwChangePage__staticPlugins, j1.`fallback` AS pwChangePage__fallback, j1.`favicon` AS pwChangePage__favicon, j1.`robotsTxt` AS pwChangePage__robotsTxt, j1.`adminEmail` AS pwChangePage__adminEmail, j1.`dateFormat` AS pwChangePage__dateFormat, j1.`timeFormat` AS pwChangePage__timeFormat, j1.`datimFormat` AS pwChangePage__datimFormat, j1.`validAliasCharacters` AS pwChangePage__validAliasCharacters, j1.`createSitemap` AS pwChangePage__createSitemap, j1.`sitemapName` AS pwChangePage__sitemapName, j1.`useSSL` AS pwChangePage__useSSL, j1.`autoforward` AS pwChangePage__autoforward, j1.`protected` AS pwChangePage__protected, j1.`groups` AS pwChangePage__groups, j1.`includeLayout` AS pwChangePage__includeLayout, j1.`layout` AS pwChangePage__layout, j1.`includeCache` AS pwChangePage__includeCache, j1.`cache` AS pwChangePage__cache, j1.`alwaysLoadFromCache` AS pwChangePage__alwaysLoadFromCache, j1.`clientCache` AS pwChangePage__clientCache, j1.`includeChmod` AS pwChangePage__includeChmod, j1.`cuser` AS pwChangePage__cuser, j1.`cgroup` AS pwChangePage__cgroup, j1.`chmod` AS pwChangePage__chmod, j1.`noSearch` AS pwChangePage__noSearch, j1.`requireItem` AS pwChangePage__requireItem, j1.`cssClass` AS pwChangePage__cssClass, j1.`sitemap` AS pwChangePage__sitemap, j1.`hide` AS pwChangePage__hide, j1.`guests` AS pwChangePage__guests, j1.`tabindex` AS pwChangePage__tabindex, j1.`accesskey` AS pwChangePage__accesskey, j1.`published` AS pwChangePage__published, j1.`start` AS pwChangePage__start, j1.`stop` AS pwChangePage__stop, j1.`enforceTwoFactor` AS pwChangePage__enforceTwoFactor, j1.`twoFactorJumpTo` AS pwChangePage__twoFactorJumpTo, j1.`dlh_googlemaps_apikey` AS pwChangePage__dlh_googlemaps_apikey, j1.`pwChangePage` AS pwChangePage__pwChangePage, j1.`catalogUseMaster` AS pwChangePage__catalogUseMaster, j1.`catalogShowInBreadcrumb` AS pwChangePage__catalogShowInBreadcrumb, j1.`catalogUseChangeLanguage` AS pwChangePage__catalogUseChangeLanguage, j1.`catalogUseRouting` AS pwChangePage__catalogUseRouting, j1.`catalogRoutingParameter` AS pwChangePage__catalogRoutingParameter, j1.`catalogSetAutoItem` AS pwChangePage__catalogSetAutoItem, j1.`catalogRouting` AS pwChangePage__catalogRouting, j1.`catalogChangeLanguageTable` AS pwChangePage__catalogChangeLanguageTable, j1.`catalogMasterTable` AS pwChangePage__catalogMasterTable, j1.`catalogRoutingTable` AS pwChangePage__catalogRoutingTable, j1.`cms_root_license` AS pwChangePage__cms_root_license, j1.`cms_exclude_health_check` AS pwChangePage__cms_exclude_health_check, j1.`cms_root_key` AS pwChangePage__cms_root_key, j1.`cms_root_data` AS pwChangePage__cms_root_data, j1.`cms_root_sign` AS pwChangePage__cms_root_sign, j1.`cms_mi_views` AS pwChangePage__cms_mi_views, j1.`cms_mi_reset` AS pwChangePage__cms_mi_reset FROM tl_page LEFT JOIN tl_page j1 ON tl_page.`pwChangePage`=j1.id WHERE type='root' AND (tl_page.dns='my-domain.tld' OR tl_page.dns='') LIMIT 0,1':

SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'type' in where clause is ambiguous`
```