### PR TITLE
Fixed namespace errors for Contao >=5.3

### DIFF
--- a/src/Resources/contao/templates/backend/modules/dashboard_items/item_a_b_test.html5
+++ b/src/Resources/contao/templates/backend/modules/dashboard_items/item_a_b_test.html5
@@ -18,7 +18,7 @@
                 </div>
                 <div class="reset">
                     <?php if( $this->groups[0]['reset'] > 0 ): ?>
-                        <p><?= sprintf( $GLOBALS['TL_LANG']['LABEL']['reset_since'], \Date::parse(\Config::get('datimFormat'), $this->groups[0]['reset']) ); ?></p>
+                        <p><?= sprintf( $GLOBALS['TL_LANG']['LABEL']['reset_since'], Contao\Date::parse(Contao\Config::get('datimFormat'), $this->groups[0]['reset']) ); ?></p>
                     <?php endif; ?>
                 </div>
                 <table>

--- a/src/Resources/contao/templates/backend/modules/dashboard_items/item_a_b_test_page.html5
+++ b/src/Resources/contao/templates/backend/modules/dashboard_items/item_a_b_test_page.html5
@@ -17,7 +17,7 @@
         </div>
         <div class="reset">
             <?php if( $this->pages[0]['cms_mi_reset'] > 0 ): ?>
-                <p><?= sprintf( $GLOBALS['TL_LANG']['LABEL']['reset_since'], \Date::parse(\Config::get('datimFormat'), $this->pages[0]['cms_mi_reset']) ); ?></p>
+                <p><?= sprintf( $GLOBALS['TL_LANG']['LABEL']['reset_since'], Contao\Date::parse(Contao\Config::get('datimFormat'), $this->pages[0]['cms_mi_reset']) ); ?></p>
             <?php endif; ?>
         </div>
         <table>


### PR DESCRIPTION
Fixes ClassNotFound Exception due to missing namespaces
<img width="1076" height="327" alt="image" src="https://github.com/user-attachments/assets/bb4a8f9e-9690-4291-af79-72e3c8a41bc0" />
